### PR TITLE
Add container and header layout variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ This project contains React components that use the styles from [Nenkan CSS](htt
 
 You can use it as building blocks for a user interface.
 
+## Notable layout props
+
+- `Container` supports `variant="fixed" | "fluid"`.
+- `Header` supports `containerVariant="fixed" | "fluid"` and `innerClassName`.
+
 You can see the production storybook at https://www.nen-kan.com/ui
 
 ## Contributing

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@babel/preset-react": "^7.28.5",
         "@babel/preset-typescript": "^7.28.5",
         "@eslint/js": "^10.0.1",
-        "@nenkan/css": "0.25.0",
+        "@nenkan/css": "0.25.1",
         "babel-loader": "^10.1.1",
         "css-loader": "^7.1.4",
         "eslint": "^10.4.0",
@@ -1936,9 +1936,9 @@
       }
     },
     "node_modules/@nenkan/css": {
-      "version": "0.25.0",
-      "resolved": "https://npm.pkg.github.com/download/@nenkan/css/0.25.0/856a4360903c4df01bb97ab57a11ccadfbb67ef1",
-      "integrity": "sha512-V53gcr5vy/Poo+85GWRUuMBEGm+olBsrzPQriZeMpUTQzFjtju3gAmp0X//PMzKb/MLUMm7KbOVzm/nk4rSAvQ==",
+      "version": "0.25.1",
+      "resolved": "https://npm.pkg.github.com/download/@nenkan/css/0.25.1/76cac18fb1e3a2577754b79c8c4a64d4c4743a73",
+      "integrity": "sha512-mMCO0W1GKCOQo8Ve9d8jsMIBQVZLNk2efF6/cNuNnS7t5ocyJrcQyZz+JHsNtL+dky/wQk6C0Z9Hq0Uvv2Ee/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -8683,9 +8683,9 @@
       }
     },
     "@nenkan/css": {
-      "version": "0.25.0",
-      "resolved": "https://npm.pkg.github.com/download/@nenkan/css/0.25.0/856a4360903c4df01bb97ab57a11ccadfbb67ef1",
-      "integrity": "sha512-V53gcr5vy/Poo+85GWRUuMBEGm+olBsrzPQriZeMpUTQzFjtju3gAmp0X//PMzKb/MLUMm7KbOVzm/nk4rSAvQ==",
+      "version": "0.25.1",
+      "resolved": "https://npm.pkg.github.com/download/@nenkan/css/0.25.1/76cac18fb1e3a2577754b79c8c4a64d4c4743a73",
+      "integrity": "sha512-mMCO0W1GKCOQo8Ve9d8jsMIBQVZLNk2efF6/cNuNnS7t5ocyJrcQyZz+JHsNtL+dky/wQk6C0Z9Hq0Uvv2Ee/Q==",
       "dev": true
     },
     "@nicolo-ribaudo/chokidar-2": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nenkan/ui",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nenkan/ui",
-      "version": "0.27.0",
+      "version": "0.28.0",
       "license": "MIT",
       "dependencies": {
         "classnames": "^2.5.1",
@@ -21,7 +21,7 @@
         "@babel/preset-react": "^7.28.5",
         "@babel/preset-typescript": "^7.28.5",
         "@eslint/js": "^10.0.1",
-        "@nenkan/css": "0.24.1",
+        "@nenkan/css": "0.25.0",
         "babel-loader": "^10.1.1",
         "css-loader": "^7.1.4",
         "eslint": "^10.4.0",
@@ -1936,9 +1936,9 @@
       }
     },
     "node_modules/@nenkan/css": {
-      "version": "0.24.1",
-      "resolved": "https://npm.pkg.github.com/download/@nenkan/css/0.24.1/995cf1ad0c965e27bf34009ac33f1642a88a89bb",
-      "integrity": "sha512-LSFs7cMoku6ShZwUZIbT90yAN1KWxrRfJe9p793dR8ATyhXuefzZ2HqOUxjxBXd5A9baHF8xlFLZB09n9jZ2Qw==",
+      "version": "0.25.0",
+      "resolved": "https://npm.pkg.github.com/download/@nenkan/css/0.25.0/856a4360903c4df01bb97ab57a11ccadfbb67ef1",
+      "integrity": "sha512-V53gcr5vy/Poo+85GWRUuMBEGm+olBsrzPQriZeMpUTQzFjtju3gAmp0X//PMzKb/MLUMm7KbOVzm/nk4rSAvQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -8683,9 +8683,9 @@
       }
     },
     "@nenkan/css": {
-      "version": "0.24.1",
-      "resolved": "https://npm.pkg.github.com/download/@nenkan/css/0.24.1/995cf1ad0c965e27bf34009ac33f1642a88a89bb",
-      "integrity": "sha512-LSFs7cMoku6ShZwUZIbT90yAN1KWxrRfJe9p793dR8ATyhXuefzZ2HqOUxjxBXd5A9baHF8xlFLZB09n9jZ2Qw==",
+      "version": "0.25.0",
+      "resolved": "https://npm.pkg.github.com/download/@nenkan/css/0.25.0/856a4360903c4df01bb97ab57a11ccadfbb67ef1",
+      "integrity": "sha512-V53gcr5vy/Poo+85GWRUuMBEGm+olBsrzPQriZeMpUTQzFjtju3gAmp0X//PMzKb/MLUMm7KbOVzm/nk4rSAvQ==",
       "dev": true
     },
     "@nicolo-ribaudo/chokidar-2": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nenkan/ui",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "Reusable React components following Nenkan styles",
   "exports": "./dist/index.js",
   "private": true,
@@ -32,7 +32,7 @@
     "@babel/preset-react": "^7.28.5",
     "@babel/preset-typescript": "^7.28.5",
     "@eslint/js": "^10.0.1",
-    "@nenkan/css": "0.24.1",
+    "@nenkan/css": "0.25.0",
     "babel-loader": "^10.1.1",
     "css-loader": "^7.1.4",
     "eslint": "^10.4.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@babel/preset-react": "^7.28.5",
     "@babel/preset-typescript": "^7.28.5",
     "@eslint/js": "^10.0.1",
-    "@nenkan/css": "0.25.0",
+    "@nenkan/css": "0.25.1",
     "babel-loader": "^10.1.1",
     "css-loader": "^7.1.4",
     "eslint": "^10.4.0",

--- a/src/container.d.ts
+++ b/src/container.d.ts
@@ -4,6 +4,7 @@ interface ContainerProps {
   as?: string;
   children: React.ReactNode;
   className?: string;
+  variant?: 'fixed' | 'fluid';
 }
 declare function Container(props: ContainerProps): JSX.Element;
 export default Container;

--- a/src/container.tsx
+++ b/src/container.tsx
@@ -4,7 +4,13 @@ import classNames from 'classnames';
 export default function Container(props) {
   const ElementTag = props.as || 'div';
   return (
-    <ElementTag className={classNames('container', props.className)}>
+    <ElementTag
+      className={classNames(
+        'container',
+        props.variant === 'fluid' && 'container--fluid',
+        props.className,
+      )}
+    >
       {props.children}
     </ElementTag>
   );

--- a/src/header.d.ts
+++ b/src/header.d.ts
@@ -3,6 +3,8 @@ import React from 'react';
 interface HeaderProps {
   children: React.ReactNode;
   className?: string;
+  containerVariant?: 'fixed' | 'fluid';
+  innerClassName?: string;
 }
 declare function Header(props: HeaderProps): JSX.Element;
 export default Header;

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
 import classNames from 'classnames';
+import Container from './container.js';
 
 export default function Header(props) {
   return (
     <header className={classNames('header', props.className)}>
-      <div className="container header__inner">
+      <Container
+        className={classNames('header__inner', props.innerClassName)}
+        variant={props.containerVariant || 'fixed'}
+      >
         {props.children}
-      </div>
+      </Container>
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- add Container prop ariant=\"fixed\" | \"fluid\"
- add Header props containerVariant and innerClassName
- update README with the new layout-related props

## Why
Apps should not need custom header/container overrides to align shell gutters. This exposes reusable layout primitives through @nenkan/ui while keeping backwards compatibility.

## Design inspirations
- Radix composable prop-driven API style
- Bootstrap fixed/fluid container variants
- Material/Fluent responsive layout spacing patterns
